### PR TITLE
feat: add file filtering by mime-type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
         <run.addResources>false</run.addResources>
         <spring-security.version>4.2.18.RELEASE</spring-security.version>
         <springfox.version>2.4.0</springfox.version>
+        <apache-tika.version>1.26</apache-tika.version>
         <!-- Sonar properties -->
         <project.testresult.directory>${project.build.directory}/test-results</project.testresult.directory>
         <sonar-maven-plugin.version>3.0.2</sonar-maven-plugin.version>
@@ -427,7 +428,11 @@
             <version>1.18.12</version>
             <scope>provided</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.apache.tika</groupId>
+            <artifactId>tika-core</artifactId>
+            <version>${apache-tika.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <defaultGoal>spring-boot:run</defaultGoal>

--- a/src/main/java/io/klask/config/KlaskProperties.java
+++ b/src/main/java/io/klask/config/KlaskProperties.java
@@ -41,9 +41,7 @@ public class KlaskProperties {
 
         private List<String> filesToExclude = new ArrayList<>();
 
-        private List<String> filesToInclude = new ArrayList<>();
-
-        private List<String> extensionsToRead = new ArrayList<>();
+        private List<String> mimesToExclude = new ArrayList<>();
 
         private int batchSize = 25;
 
@@ -103,20 +101,12 @@ public class KlaskProperties {
             this.extensionsToExclude = extensionsToExclude;
         }
 
-        public List<String> getFilesToInclude() {
-            return filesToInclude;
+        public List<String> getMimesToExclude() {
+            return mimesToExclude;
         }
 
-        public void setFilesToInclude(List<String> filesToInclude) {
-            this.filesToInclude = filesToInclude;
-        }
-
-        public List<String> getExtensionsToRead() {
-            return extensionsToRead;
-        }
-
-        public void setExtensionsToRead(List<String> extensionsToRead) {
-            this.extensionsToRead = extensionsToRead;
+        public void setMimesToExclude(List<String> mimesToExclude) {
+            this.mimesToExclude = mimesToExclude;
         }
 
         public int getBatchSize() {

--- a/src/main/java/io/klask/crawler/impl/FileSystemCrawler.java
+++ b/src/main/java/io/klask/crawler/impl/FileSystemCrawler.java
@@ -150,8 +150,7 @@ public class FileSystemCrawler extends GenericCrawler implements ICrawler {
         long size = attrs.size();
 
         String content = null;
-        if ((!readableExtensionSet.contains(extension) && !"".equals(extension))
-            || size > Constants.MAX_SIZE_FOR_INDEXING_ONE_FILE) {
+        if (size > Constants.MAX_SIZE_FOR_INDEXING_ONE_FILE || isFileInExclusion(path)) {
             log.trace("parsing only name on file : {}", path);
         } else {
             content = readContent(path);

--- a/src/main/java/io/klask/crawler/impl/GitCrawler.java
+++ b/src/main/java/io/klask/crawler/impl/GitCrawler.java
@@ -3,7 +3,6 @@ package io.klask.crawler.impl;
 import static org.eclipse.jgit.lib.Constants.OBJ_BLOB;
 
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -95,8 +94,7 @@ public class GitCrawler extends GenericCrawler implements ICrawler {
 
 
         String content = null;
-        if ((!readableExtensionSet.contains(extension) && !"".equals(extension))
-            || size > Constants.MAX_SIZE_FOR_INDEXING_ONE_FILE) {
+        if (size > Constants.MAX_SIZE_FOR_INDEXING_ONE_FILE || isFileInExclusion(path)) {
             log.trace("parsing only name on file : {}", path);
         } else {
             content = readContent(path);
@@ -236,12 +234,12 @@ public class GitCrawler extends GenericCrawler implements ICrawler {
 
                             String content = null;
 
-                            if ((!readableExtensionSet.contains(extension) && !"".equals(extension))
-                                    || size > Constants.MAX_SIZE_FOR_INDEXING_ONE_FILE) {
+                            if (size > Constants.MAX_SIZE_FOR_INDEXING_ONE_FILE
+                                    || isFileInExclusion(workingDir.resolve(pathAndFileName))) {
                                 log.trace("parsing only name on file : {}", pathAndFileName);
                             } else {
                                 byte[] bytes = loader.getBytes();
-                                content = new String(bytes, Charset.forName("utf-8"));
+                                content = new String(bytes, StandardCharsets.UTF_8);
                                 log.trace("tree size    : {}", loader.getSize());
                             }
                             String pathComplet = this.repository.getPath() + "@" + branch + ":/" + pathAndFileName;

--- a/src/main/java/io/klask/crawler/impl/GitlabCrawler.java
+++ b/src/main/java/io/klask/crawler/impl/GitlabCrawler.java
@@ -42,7 +42,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.Future;
 import java.util.stream.Stream;
 
@@ -227,8 +226,8 @@ public class GitlabCrawler extends GenericCrawler implements ICrawler {
 
                         String content = null;
 
-                        if ((!readableExtensionSet.contains(extension) && !"".equals(extension))
-                            || size > Constants.MAX_SIZE_FOR_INDEXING_ONE_FILE) {
+                        if (size > Constants.MAX_SIZE_FOR_INDEXING_ONE_FILE
+                                || isFileInExclusion(workingDir.resolve(pathAndFileName))) {
                             log.trace("parsing only name on file : {}", pathAndFileName);
                         } else {
                             content = new String(loader.getBytes(), StandardCharsets.UTF_8);

--- a/src/main/java/io/klask/crawler/impl/SVNCrawler.java
+++ b/src/main/java/io/klask/crawler/impl/SVNCrawler.java
@@ -216,21 +216,7 @@ public class SVNCrawler extends GenericCrawler implements ICrawler {
      * initialize the SVN repository with the protocols beginning in the URL
      */
     private void initialize() throws SVNException {
-        directoriesToExcludeSet.clear();
-        directoriesToExcludeSet.addAll(klaskProperties.getCrawler().getDirectoriesToExclude());
-        log.debug("exclude directories {}", directoriesToExcludeSet);
-
-        filesToExcludeSet.clear();
-        filesToExcludeSet.addAll(klaskProperties.getCrawler().getFilesToExclude());
-        log.debug("exclude files : {}", filesToExcludeSet);
-
-        extensionsToExcludeSet.clear();
-        extensionsToExcludeSet.addAll(klaskProperties.getCrawler().getExtensionsToExclude());
-        log.debug("exclude extensions : {}", extensionsToExcludeSet);
-
-        readableExtensionSet.clear();
-        readableExtensionSet.addAll(klaskProperties.getCrawler().getExtensionsToRead());
-        log.debug("ascii files with extension : {}", readableExtensionSet);
+        this.initializeProperties();
 
         //Set up connection protocols support:
         if (this.svnRepository == null && this.repository != null && this.repository.getPath() != null) {

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -97,5 +97,21 @@ klask:
             - sha1
             - md5
         filesToExclude: .project,.classpath,swagger-ui.js,angular.min.js.map,bootstrap.css.map,bootstrap.css.map,angular.min.js.map,jquery.min.map,angular.min.js
-        extensionsToRead: java,properties,txt,xml,js,jsp,html,htm,php,asm,md,json,sh,bat,sql,yml,yaml,pom,scala,dtd,c,cpp,h,pc,as,mxml,xsl,xslt,tld,asp,jrxml,conf,desc,gs,less,scss,css,ini,groovy,gradle,policy,py,go,toml,rs
-
+        mimesToExclude:
+            - application/octet-stream
+            - application/java-archive
+            - image/bmp
+            - image/gif
+            - image/jpeg
+            - image/png
+            - image/tiff
+            - audio/aac
+            - audio/midi
+            - audio/mpeg
+            - audio/ogg
+            - audio/wav
+            - audio/3gpp
+            - video/mp4
+            - video/mpeg
+            - video/ogg
+            - video/3gpp

--- a/src/test/java/io/klask/crawler/impl/GenericCrawlerTest.java
+++ b/src/test/java/io/klask/crawler/impl/GenericCrawlerTest.java
@@ -1,0 +1,63 @@
+package io.klask.crawler.impl;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import io.klask.config.KlaskProperties;
+
+public class GenericCrawlerTest {
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    @Test
+    public void isFileInExclusionWithExcludedFilesTest() throws IOException {
+        Path[] outFile = new Path[] {
+                tempFolder.newFile("file.js").toPath(),
+                tempFolder.newFile("file.js~").toPath(),
+                tempFolder.newFile("file.test").toPath(),
+                tempFolder.newFile("something").toPath(),
+        };
+
+        KlaskProperties conf = new KlaskProperties();
+        conf.getCrawler().getMimesToExclude().add("application/javascript");
+        conf.getCrawler().getExtensionsToExclude().add("test");
+        conf.getCrawler().getFilesToExclude().add("something");
+        GenericCrawler gc = new GenericCrawler(null, conf , null) { };
+        gc.initializeProperties();
+
+        for (Path path : outFile) {
+            boolean excludedFile = gc.isFileInExclusion(path);
+            assertTrue("File " + path + " must be excluded and it wasn't", excludedFile);
+        }
+    }
+
+    @Test
+    public void isFileInExclusionWithIncludedFilesTest() throws IOException {
+        Path[] inFiles = new Path[] {
+                tempFolder.newFile("file.java").toPath(),
+                tempFolder.newFile("file").toPath(),
+                tempFolder.newFile("file.test.more").toPath(),
+                tempFolder.newFile("something-else").toPath(),
+        };
+
+        KlaskProperties conf = new KlaskProperties();
+        conf.getCrawler().getMimesToExclude().add("application/javascript");
+        conf.getCrawler().getExtensionsToExclude().add("test");
+        conf.getCrawler().getFilesToExclude().add("something");
+        GenericCrawler gc = new GenericCrawler(null, conf , null) { };
+        gc.initializeProperties();
+
+        for (Path path : inFiles) {
+            boolean includedFile = gc.isFileInExclusion(path);
+            assertFalse("File " + path + " must not be excluded and it was", includedFile);
+        }
+    }
+}

--- a/src/test/java/io/klask/crawler/svn/SVNVisitorCrawlerTest.java
+++ b/src/test/java/io/klask/crawler/svn/SVNVisitorCrawlerTest.java
@@ -11,6 +11,7 @@ import org.tmatesoft.svn.core.io.diff.SVNDeltaProcessor;
 
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Path;
 
 /**
  * Created by harelj on 15/03/2017.
@@ -51,7 +52,7 @@ public class SVNVisitorCrawlerTest {
         repoMock.setPath("svn://localhost");
         //when
         Mockito.when(svnCrawler.getRepository()).thenReturn(repoMock);
-        Mockito.when(svnCrawler.isReadableExtension(Matchers.anyString())).thenReturn(true);
+        Mockito.when(svnCrawler.isFileInExclusion(Matchers.any(Path.class))).thenReturn(false);
 
         this.svnVisitorCrawler.openRoot(1000);
         this.svnVisitorCrawler.addDir("/",null,-1);


### PR DESCRIPTION
Changes the file filtering from a list of included files to a list of excluded media-types.

I added a few common MIMEs to the application.properties, but feel free to enrich it.
Here is the complete list of MIMEs with more than 1800 lines :scream: : https://www.iana.org/assignments/media-types/media-types.xhtml

Have fun :sweat_smile: 